### PR TITLE
update link to join Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For questions about this repository, please file an issue on the `community` rep
 | --- | --- | --- | --- |
 | [Discourse Forum](https://discuss.ray.io/) |	For discussions about development and questions about usage. |	< 1 day	| Community |
 | [GitHub Issues](https://github.com/ray-project/ray)	| For reporting bugs and filing feature requests. |	< 2 days	| Ray OSS Team |
-| [Slack](https://github.com/ray-project/ray/issues)	| For collaborating with other Ray users.	| < 2 days	| Community |
+| [Slack](https://www.ray.io/join-slack)	| For collaborating with other Ray users.	| < 2 days	| Community |
 | [StackOverflow](https://stackoverflow.com/questions/tagged/ray) |	For asking questions about how to use Ray.	| 3-5 days	| Community |
 | [Meetup Group](https://www.meetup.com/Bay-Area-Ray-Meetup/) |	For learning about Ray projects and best practices.	| Monthly |	Ray DevRel |
 | [Twitter](https://twitter.com/raydistributed)	| For staying up-to-date on new features.	| Daily	| Ray DevRel |


### PR DESCRIPTION
Update link to join Slack. Currently it links to https://github.com/ray-project/ray/issues, which seems unintentional.